### PR TITLE
Fix for clojure:swank test resources

### DIFF
--- a/src/main/java/com/theoryinpractise/clojure/ClojureSwankMojo.java
+++ b/src/main/java/com/theoryinpractise/clojure/ClojureSwankMojo.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 /**
  * @goal swank
- * @execute phase="compile"
+ * @execute phase="test-compile"
  * @requiresDependencyResolution test
  */
 public class ClojureSwankMojo extends AbstractClojureCompilerMojo {


### PR DESCRIPTION
I ran into an issue that files from src/test/resources weren't being found when using clojure:swank.  I found that the src/test/resources/\* files weren't being copied into the test-classes directory of target. To reproduce this, run mvn clean, then mvn clojure:swank.  The src/test/resources/\* files will not have been copied over to the target directory and will not be on the classpath.  If I run mvn test separately, then run clojure:swank, the files are in target and the tests ran through swank work. I switched the swank mojo to the test-compile phase and it resolved my issue.
