### PR TITLE
Vimclojure 2.2.0 related changes

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -248,10 +248,10 @@ swank server runs against, you can configure it via:
 
 or by defining the clojure.swank.host system property.
 
-#### Nailgun
+#### Nailgun for Vimclojure < 2.2.0
 
 The clojure:nailgun goal requires a recent version of vimclojure as a
-dependency. Unfortunatly, this library is currently not available in
+dependency. Unfortunately, this library is currently not available in
 the central maven repository, and has to be downloaded and installed
 manually:
 
@@ -269,6 +269,42 @@ manually:
 		<version>X.X.X</version>
     	</dependency>
 
+ 5. You will need to run `mvn clojure:nailgun -Dclojure.nailgun.server=com.martiansoftware.nailgun.NGServer` in order to
+    work with the old version (pre 2.2.0) of vimclojure.
+
+#### Nailgun for Vimclojure >= 2.2.0
+
+To use `clojure 1.2.0` comfortably, you will need to upgrade to `Vimclojure
+2.2.0` which isn't backwards compatible with previous vimclojure versions.  Now
+you will need a dependency on the `vimclojure:server:2.2.0` which contains the
+modified Nailgun server.
+
+    <dependency>
+        <groupId>vimclojure</groupId>
+        <artifactId>server</artifactId>
+        <version>2.2.0</version>
+    </dependency>
+
+The jar can be found in [clojars](http://clojars.org/) maven repo (you'll have
+to add it to the `repositories` section)
+
+    <repository>
+        <id>clojars</id>
+        <name>Clojars</name>
+        <url>http://clojars.org/repo/</url>
+    </repository>
+
+The installation process for vimclojure remains the same (except for the
+`vimclojure.jar` which you don't need to install anymore).  Just get the
+vimclojure package from http://kotka.de/projects/clojure/vimclojure.html and
+follow the README.
+
+Notes for migration from the previous version of vimclojure:
+
+* `clj_highlight_builtins` was deprecated in favor of `vimclojure#HighlightBuiltins`
+* `clj_highlight_contrib` was removed
+* `g:clj_paren_rainbow` was deprecated in favor of `vimclojure#ParenRainbow`
+* `g:clj_want_gorilla` was deprecated in favor of `vimclojure#WantNailgun`
 
 ### Configuration
 

--- a/src/main/java/com/theoryinpractise/clojure/ClojureNailgunMojo.java
+++ b/src/main/java/com/theoryinpractise/clojure/ClojureNailgunMojo.java
@@ -35,13 +35,19 @@ public class ClojureNailgunMojo extends AbstractClojureCompilerMojo {
      */
     protected int port;
 
+    /**
+     * pre vimclojure 2.2.0: com.martiansoftware.nailgun.NGServer
+     * @parameter expression="${clojure.nailgun.server}" default-value="vimclojure.nailgun.NGServer"
+     */
+    protected String server;
+
     public void execute() throws MojoExecutionException {
 
         String[] args = new String[]{Integer.toString(port)};
         callClojureWith(getSourceDirectories(SourceDirectory.TEST, SourceDirectory.COMPILE),
                 outputDirectory,
                 getRunWithClasspathElements(),
-                "com.martiansoftware.nailgun.NGServer", args);
+                server, args);
     }
 
 }


### PR DESCRIPTION
As noted [here](http://groups.google.com/group/clojure/browse_thread/thread/303f8690c0aa28fb), 

> VimClojure now requires a patched version of nailgun. The new class to execute is called 
> `vimclojure.nailgun.NGServer` compared to the previous `com.martiansoftware.nailgun.NGServer`. 

I basically made the server classname overrideable through maven properties and set the new classname as the default (in the Nailgun mojo). Also updated the README.
Feel free to devise whatever other scheme you think will work better, as the one I chose breaks backwards compatibility.
