### PR TITLE
Feature/honour skip tests

### DIFF
--- a/src/main/java/com/theoryinpractise/clojure/ClojureRunTestMojo.java
+++ b/src/main/java/com/theoryinpractise/clojure/ClojureRunTestMojo.java
@@ -34,6 +34,14 @@ public class ClojureRunTestMojo extends AbstractClojureCompilerMojo {
     private boolean skip;
 
     /**
+     * Flag to allow test execution to be skipped.
+     *
+     * @parameter expression="${skipTests}" default-value="false"
+     * @noinspection UnusedDeclaration
+     */
+    private boolean skipTests;
+
+    /**
      * The main clojure script to run
      *
      * @parameter
@@ -41,7 +49,7 @@ public class ClojureRunTestMojo extends AbstractClojureCompilerMojo {
     private String testScript;
 
     public void execute() throws MojoExecutionException {
-        if (skip) {
+        if (skip || skipTests) {
             getLog().info("Test execution is skipped");
         } else {
 


### PR DESCRIPTION
Useful for projects that produce test jars. -DskipTests=true prevents
test execution while still building the test jars.
