### PR TITLE
Updated marginalia mojo to work with 0.6.0 version

### DIFF
--- a/src/it/marginalia/pom.xml
+++ b/src/it/marginalia/pom.xml
@@ -53,7 +53,7 @@
 		<dependency>
 		  <groupId>marginalia</groupId>
 		  <artifactId>marginalia</artifactId>
-		  <version>0.3.2</version>
+		  <version>0.6.0</version>
                   <exclusions>
                     <exclusion>
                       <groupId>org.clojure</groupId>

--- a/src/main/java/com/theoryinpractise/clojure/ClojureMarginaliaMojo.java
+++ b/src/main/java/com/theoryinpractise/clojure/ClojureMarginaliaMojo.java
@@ -171,6 +171,7 @@ public class ClojureMarginaliaMojo extends AbstractClojureCompilerMojo {
     sb.append("(ensure-directory! \"");
     sb.append(marginaliaTargetDirectory);
     sb.append("\")\n");
+    sb.append("(binding [marginalia.html/*resources* \"\"]");
 
     sb.append("(uberdoc!\n");
 
@@ -196,7 +197,7 @@ public class ClojureMarginaliaMojo extends AbstractClojureCompilerMojo {
 
     // and the project map
     sb.append(formatMap(effectiveProps));
-    sb.append(")\n");
+    sb.append("))\n");
 
     // Run it
     try {


### PR DESCRIPTION
There is an additional dynamic binding in marginalia which has to be
reset in order to correctly internalize resources into the uberdoc.
