### PR TITLE
Deleting of dependent files after aot compile

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -96,7 +96,7 @@ configuration block:
     
 ### Excluding dependent classes after clojure's aot compilation
 
-When clojure compiler compiles namespace with gen-classes it recursively pulls all dependent classes. See [CLJ-322](http://dev.clojure.org/jira/browse/CLJ-322)
+When clojure compiler compiles namespace with <i>gen-class</i> directive it recursively pulls all dependent classes. See [CLJ-322](http://dev.clojure.org/jira/browse/CLJ-322)
 
 In some maven build environments such behavior could be redundant. 
 The following configuration will delete dependent class files from outputDirecotry after clojure's AOT compile step.

--- a/README.markdown
+++ b/README.markdown
@@ -93,8 +93,26 @@ configuration block:
       <compileDeclaredNamespaceOnly>true</compileDeclaredNamespaceOnly>
       <testDeclaredNamespaceOnly>true</testDeclaredNamespaceOnly>
     </configuration>
+    
+### Excluding dependent classes after clojure's aot compilation
 
-## Interactive Coding
+When clojure compiler compiles namespace with gen-classes it recursively pulls all dependent classes. See [CLJ-322](http://dev.clojure.org/jira/browse/CLJ-322)
+
+In some maven build environments such behavior could be redundant. 
+The following configuration will delete dependent class files from outputDirecotry after clojure's AOT compile step.
+
+    <configuration>
+        <keepNamespaces>
+            <keepNamespace>foo.bar</keepNamespace>
+        </keepNamespaces>
+    </configuration>
+ 
+Multiple <i>keepNamespace</i> elements are supported and clojure's namespace mangling rules are expected:
+1.   at least to parts separated by '.'
+2.   last part becomes a start of class file
+3.   '-' is translated into '\_'
+
+### Interactive Coding
 
 The plugin supports several goals intended to make it easier for developers to run interactive clojure shells
 in the context of maven projects.  This means that all dependencies in a project's runtime and test scopes

--- a/README.markdown
+++ b/README.markdown
@@ -108,9 +108,10 @@ The following configuration will delete dependent class files from outputDirecot
     </configuration>
  
 Multiple <i>keepNamespace</i> elements are supported and clojure's namespace mangling rules are expected:
-1.   at least to parts separated by '.'
-2.   last part becomes a start of class file
-3.   '-' is translated into '\_'
+
+ 1.   at least to parts separated by '.'
+ 2.   last part becomes a start of class file
+ 3.   '-' is translated into '\_'
 
 ### Interactive Coding
 

--- a/src/main/java/com/theoryinpractise/clojure/ClojureCompilerMojo.java
+++ b/src/main/java/com/theoryinpractise/clojure/ClojureCompilerMojo.java
@@ -52,6 +52,10 @@ public class ClojureCompilerMojo extends AbstractClojureCompilerMojo {
                 discoverNamespaces());
 
         copyNamespaceSourceFilesToOutput(outputDirectory, discoverNamespacesToCopy());
+        
+        if (keepNamespaces != null && keepNamespaces.length > 0) {
+        	deleteAotDependentClasses(outputDirectory, keepNamespaces);
+        }
     }
 
 }


### PR DESCRIPTION
When clojure compiler compiles namespace with gen-class directive it recursively pulls all dependent classes. See [CLJ-322](http://dev.clojure.org/jira/browse/CLJ-322)

In some maven build environments such behavior could be redundant. The following configuration will delete dependent class files from outputDirecotry after clojure's AOT compile step.

`<configuration>
    <keepNamespaces>
        <keepNamespace>foo.bar</keepNamespace>
    </keepNamespaces>
</configuration>
`
Multiple keepNamespace elements are supported and clojure's namespace mangling rules are expected:
1. at least to parts separated by '.'
2. last part becomes a start of class file
3. '-' is translated into '_'
