### PR TITLE
Support for midje facts wrapped with deftest 

### DIFF
--- a/src/main/resources/default_test_script.clj
+++ b/src/main/resources/default_test_script.clj
@@ -19,14 +19,20 @@
         (.write writer text)))
     ))
 
+(defn total_errors [summary]
+  (+ (:error summary) (:fail summary)))
+
+(defn summary [results]
+  (first (filter #(-> % :type (= :summary)) results)))
+
 (when-not *compile-files*
   (let [results (atom [])]
     (let [report-orig report
           junit-report-orig junit-report]
       (binding [report (fn [x] (report-orig x)
-                         (swap! results conj (:type x)))
+                         (swap! results conj x))
                 junit-report (fn [x] (junit-report-orig x)
-                         (swap! results conj (:type x)))]
+                         (swap! results conj x))]
         (run-tests)))
     (shutdown-agents)
-    (System/exit (if (empty? (filter #{:fail :error} @results)) 0 -1))))
+    (System/exit (-> @results summary total_errors))))


### PR DESCRIPTION
as explained in https://github.com/marick/Midje/wiki/Lein-test

Midje uses other :type different from :fail and :error (like :mock-expected-result-failure) to report failures. This means that the maven-clojure-plugin is reporting a success when a Midje test fails.

 Instead of looking for :fail or :error, use the :summary report which contains the right number of errors and failure. This is what the "lein test" task does.
