### PR TITLE
Destroy subprocesses before exiting

### DIFF
--- a/src/main/java/com/theoryinpractise/clojure/AbstractClojureCompilerMojo.java
+++ b/src/main/java/com/theoryinpractise/clojure/AbstractClojureCompilerMojo.java
@@ -18,6 +18,7 @@ import org.apache.commons.exec.ExecuteException;
 import org.apache.commons.exec.ExecuteStreamHandler;
 import org.apache.commons.exec.Executor;
 import org.apache.commons.exec.PumpStreamHandler;
+import org.apache.commons.exec.ShutdownHookProcessDestroyer;
 import org.apache.commons.lang.SystemUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.execution.MavenSession;
@@ -429,6 +430,8 @@ public abstract class AbstractClojureCompilerMojo extends AbstractMojo {
         ExecuteStreamHandler handler = new PumpStreamHandler(System.out, System.err, System.in);
         exec.setStreamHandler(handler);
         exec.setWorkingDirectory(getWorkingDirectory());
+        ShutdownHookProcessDestroyer destroyer = new ShutdownHookProcessDestroyer();
+        exec.setProcessDestroyer(destroyer);
 
         int status;
         try {


### PR DESCRIPTION
Reported in trptcolin/reply#90

When the main process doesn't take responsibility for shutting down subprocesses, those subprocesses may not have access to the terminal and other resources that the main process owns when they run their shutdown hooks. 

In the case of REPLy, this means we don't get the opportunity to reset the stty hooks that jline2 installs.

Maybe there's a different / better way to accomplish this? But this does appear to do the trick for me locally, at least in the context of the proof-of-concept app that @JacekLach posted: https://github.com/JacekLach/reply-breakage
