### PR TITLE
Output human readable test results to stdout during test-with-junit.

### DIFF
--- a/src/main/resources/default_test_script.clj
+++ b/src/main/resources/default_test_script.clj
@@ -28,10 +28,16 @@
 (when-not *compile-files*
   (let [results (atom [])]
     (let [report-orig report
-          junit-report-orig junit-report]
+          junit-report-orig junit-report
+          out-orig *out*
+          test-out-orig *test-out*]
       (binding [report (fn [x] (report-orig x)
                          (swap! results conj x))
-                junit-report (fn [x] (junit-report-orig x)
+                junit-report (fn [x]
+                         (junit-report-orig x)
+                         (binding [*test-out* test-out-orig
+                                   *out*      out-orig]
+                           (report-orig x))
                          (swap! results conj x))]
         (run-tests)))
     (shutdown-agents)


### PR DESCRIPTION
This is a short term solution for making test-with-junit useful.
In the long run, it should probably be pulled into the test goal as an
'output-junit' option, as right now you have to run the tests twice or
skip the defaultTest goal to produce junit reports.
