### PR TITLE
Support for Marginalia multidoc generation

### DIFF
--- a/src/it/marginalia-multidoc/goals.txt
+++ b/src/it/marginalia-multidoc/goals.txt
@@ -1,0 +1,2 @@
+clean clojure:marginalia
+

--- a/src/it/marginalia-multidoc/pom.xml
+++ b/src/it/marginalia-multidoc/pom.xml
@@ -1,0 +1,73 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.theoryinpractise.it</groupId>
+    <artifactId>marginalia</artifactId>
+    <version>testing</version>
+    <packaging>clojure</packaging>
+
+    <name>packaging-test</name>
+    <url>http://maven.apache.org</url>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+	<repositories>
+		<repository>
+		   <id>clojure-releases</id>
+		   <url>http://build.clojure.org/releases</url>
+		 </repository>
+		 <repository>
+		   <id>clojars</id>
+		   <url>http://clojars.org/repo/</url>
+		 </repository>
+	</repositories>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.theoryinpractise</groupId>
+                <artifactId>clojure-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <extensions>true</extensions>
+                <configuration>
+	                <temporaryOutputDirectory>true</temporaryOutputDirectory>
+                    <marginalia>
+                        <multi>true</multi>
+                    </marginalia>
+	            </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.clojure</groupId>
+            <artifactId>clojure</artifactId>
+            <version>1.2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.clojure</groupId>
+            <artifactId>clojure-contrib</artifactId>
+            <version>1.2.0</version>
+        </dependency>
+		<dependency>
+		  <groupId>marginalia</groupId>
+		  <artifactId>marginalia</artifactId>
+		  <version>0.7.1</version>
+                  <exclusions>
+                    <exclusion>
+                      <groupId>org.clojure</groupId>
+                      <artifactId>clojure</artifactId>
+                    </exclusion>
+                    <exclusion>
+                      <groupId>org.clojure</groupId>
+                      <artifactId>clojure-contrib</artifactId>
+                    </exclusion>
+                  </exclusions>
+		</dependency>
+    </dependencies>
+
+</project>

--- a/src/it/marginalia-multidoc/src/main/clojure/autodoc.clj
+++ b/src/it/marginalia-multidoc/src/main/clojure/autodoc.clj
@@ -1,0 +1,6 @@
+(ns autodoc)
+
+(defn hello-world
+  "A simple hello world application."
+  []
+  (println "Hello World"))

--- a/src/it/marginalia-multidoc/verify.bsh
+++ b/src/it/marginalia-multidoc/verify.bsh
@@ -1,0 +1,6 @@
+import java.io.*;
+
+File file = new File( basedir, "target/marginalia/toc.html" );
+if ( !file.exists() ) {
+    throw new FileNotFoundException( "Could not find generated marginalia file: " + file );
+}

--- a/src/main/java/com/theoryinpractise/clojure/ClojureMarginaliaMojo.java
+++ b/src/main/java/com/theoryinpractise/clojure/ClojureMarginaliaMojo.java
@@ -146,6 +146,8 @@ public class ClojureMarginaliaMojo extends AbstractClojureCompilerMojo {
             effectiveProps.put("marginalia", formatMap(marginalia));
         }
 
+        boolean multiDoc = ( marginalia == null ? false : ("true".equals(marginalia.get("multi"))) );
+
         // Build the script to run marginalia
         StringBuilder sb = new StringBuilder();
 
@@ -157,12 +159,13 @@ public class ClojureMarginaliaMojo extends AbstractClojureCompilerMojo {
         sb.append(marginaliaTargetDirectory);
         sb.append("\")\n");
 
-        sb.append("(uberdoc!\n");
+        sb.append( multiDoc ? "(multidoc!\n" : "(uberdoc!\n" );
 
-        // Create the output file name
+        // Create the output destination
         sb.append("  \"");
         sb.append(marginaliaTargetDirectory);
-        sb.append("/uberdoc.html\"\n");
+        if ( !multiDoc ) sb.append("/uberdoc.html");
+        sb.append("\"\n");
 
         // Create the list of sources to process
         sb.append("  (format-sources [");


### PR DESCRIPTION
Hi,

I'd like to use multi-doc generation with Marginalia and changed the plugin to support this.

I created an integration test as well, but for some reason my machine has problems executing any integration test. Please bear with me.

From the commit message:

Marginalia can generate documentation for each namespace as a separate file. This commit adds a configuration option to the "marginalia" map to support this feature.

Usage:

``` xml
  <plugin>
    <groupId>com.theoryinpractise</groupId>
    <artifactId>clojure-maven-plugin</artifactId>
    <version>1.3.14-SNAPSHOT</version>
    <configuration>
      <marginalia>
        <multi>true</multi>
      </marginalia>
    </configuration>
  </plugin>
```
