### PR TITLE
Use COMPILE_PLUS_RUNTIME scope in ClojureRunMojo

### DIFF
--- a/src/main/java/com/theoryinpractise/clojure/ClojureRunMojo.java
+++ b/src/main/java/com/theoryinpractise/clojure/ClojureRunMojo.java
@@ -24,7 +24,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-@Mojo(name = "run", requiresDependencyResolution = ResolutionScope.RUNTIME )
+@Mojo(name = "run", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
 public class ClojureRunMojo extends AbstractClojureCompilerMojo {
 
     /**


### PR DESCRIPTION
In the process of upgrading a mixed Java/Clojure project from 1.3.8 to 1.3.15, we ran into a problem caused by the `requiresDependencyResolution` for `ClojureRunMojo` being changed from `COMPILE` to `RUNTIME`. We have quite a few deps that are in the `provided` scope, and this change means we have to move them to the `runtime` scope for the clojure compile goal to see them. However, moving them to `runtime` prevents the java compile goal from seeing them.

I'm no maven expert, so I don't fully understand the implications of `requiresDependencyResolution`, but changing it to `COMPILE_PLUS_RUNTIME` allows us to build, and allows all of the plugin's tests to pass.
