### PR TITLE
Close output files properly when copying source files

### DIFF
--- a/src/main/java/com/theoryinpractise/clojure/AbstractClojureCompilerMojo.java
+++ b/src/main/java/com/theoryinpractise/clojure/AbstractClojureCompilerMojo.java
@@ -317,9 +317,8 @@ public abstract class AbstractClojureCompilerMojo extends AbstractMojo {
                         while ((amountRead = is.read(buffer)) >= 0) {
                             os.write(buffer, 0, amountRead);
                         }
-                        is.close();
                     } finally {
-                        is.close();
+                        os.close();
                     }
                 } finally {
                     is.close();


### PR DESCRIPTION
I am trying to track down a problem where sometimes, especially if the build is running on Jenkins, one of my .clj files is not being included into a .jar file. I am not sure if a failure to close a file may cause this. But it may be a good fix to have regardless.
