### PR TITLE
Fix namespace discovery regexp to allow for namespaces declarations with spaces after the opening parenthese in the "( ns" form.

### DIFF
--- a/src/main/java/com/theoryinpractise/clojure/NamespaceDiscovery.java
+++ b/src/main/java/com/theoryinpractise/clojure/NamespaceDiscovery.java
@@ -37,7 +37,7 @@ public class NamespaceDiscovery {
 
     private static final String TEMPORARY_FILES_REGEXP = "^(\\.|#).*";
 
-    private final Pattern nsPattern = Pattern.compile("^\\s*\\(ns(\\s.*|$)");
+    private final Pattern nsPattern = Pattern.compile("^\\s*\\(\\s*ns(\\s.*|$)");
     private Log log;
     private boolean compileDeclaredNamespaceOnly;
     private File targetPath;


### PR DESCRIPTION
... spaces after opening parenthese : "( ns ..."