### PR TITLE
check file existence correctly if the script file is specified via absolute path

### DIFF
--- a/src/main/java/com/theoryinpractise/clojure/AbstractClojureCompilerMojo.java
+++ b/src/main/java/com/theoryinpractise/clojure/AbstractClojureCompilerMojo.java
@@ -505,12 +505,17 @@ public abstract class AbstractClojureCompilerMojo extends AbstractMojo {
   }
 
   protected boolean isExistingTestScriptFile(String path) {
-    File scriptFile = new File(path);
-    if(scriptFile.isAbsolute()){
-      return !Strings.isNullOrEmpty(path) && scriptFile.exists();
-    }else {
-      return !Strings.isNullOrEmpty(path) && new File(baseDirectory, path).exists();
+
+    if(!Strings.isNullOrEmpty(path)) {
+      File scriptFile = new File(path);
+      if (scriptFile.isAbsolute()) {
+        return scriptFile.exists();
+      } else {
+        return new File(baseDirectory, path).exists();
+      }
     }
+
+    return false;
   }
 
   protected boolean isClasspathResource(String path) {


### PR DESCRIPTION
plugin was failing to find the specified testScript on the filesystem when the path was absolute (ex, when we specified it in the pom as ${project.build.directory}/my_script.clj}), since it was trying to append this absolute path to the end of basedir.  I think this should fix it.  
