### PR TITLE
Make custom test runners much more usable

### DIFF
--- a/src/main/java/com/theoryinpractise/clojure/ClojureRunTestMojo.java
+++ b/src/main/java/com/theoryinpractise/clojure/ClojureRunTestMojo.java
@@ -105,22 +105,14 @@ public class ClojureRunTestMojo extends AbstractClojureCompilerMojo {
     for(int i = 0; i < ns.length; i++) {
       props.put("ns."+i, ns[i].getName());
     }
+    props.put("junit", "false");
+    props.put("outputDir", "/tmp/");//TODO fix this
+    props.put("xmlEscape", "false");//TODO fix this
     props.store(writer,"Test Run Properties");
   }
 
   protected void generateTestScript(PrintWriter writer, NamespaceInFile[] ns) throws IOException {
-    StringWriter testCljWriter = new StringWriter();
-    copy(ClojureRunTestMojo.class.getResourceAsStream("/default_test_script.clj"), testCljWriter);
-
-    StringBuilder runTestLine = new StringBuilder();
-    runTestLine.append("(run-tests");
-    for (NamespaceInFile namespace : ns) {
-      runTestLine.append(" '" + namespace.getName());
-    }
-    runTestLine.append(")");
-
-    writer.println(testCljWriter.toString().replace("(run-tests)", runTestLine.toString()));
-
+    copy(ClojureRunTestMojo.class.getResourceAsStream("/default_test_script.clj"), writer);
   }
 
 }

--- a/src/main/java/com/theoryinpractise/clojure/ClojureRunTestMojo.java
+++ b/src/main/java/com/theoryinpractise/clojure/ClojureRunTestMojo.java
@@ -12,62 +12,15 @@
 
 package com.theoryinpractise.clojure;
 
-import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.util.Properties;
 
-import static org.apache.commons.io.IOUtils.copy;
-
 @Mojo(name = "test", defaultPhase = LifecyclePhase.TEST, requiresDependencyResolution = ResolutionScope.TEST)
-public class ClojureRunTestMojo extends AbstractClojureCompilerMojo {
-
-  /**
-   * Flag to allow test compiliation to be skipped.
-   *
-   * @noinspection UnusedDeclaration
-   */
-  @Parameter(required = true, property = "maven.test.skip", defaultValue = "false")
-  private boolean skip;
-
-  /**
-   * Flag to allow test execution to be skipped.
-   *
-   * @noinspection UnusedDeclaration
-   */
-  @Parameter(required = true, property = "skipTests", defaultValue = "false")
-  private boolean skipTests;
-
-  /**
-   * The main clojure script to run
-   */
-  @Parameter
-  private String testScript;
-
-  /**
-   * Output directory for test results
-   *
-   * @noinspection UnusedDeclaration
-   */
-  @Parameter(defaultValue = "${project.build.directory}/test-reports", property = "clojure.testOutputDirectory")
-  private String testOutputDirectory;
-
-  /**
-   * Whether to XML escape non-report output sent to *out*
-   *
-   * @noinspection UnusedDeclaration
-   */
-  @Parameter(defaultValue = "true", property = "clojure.xmlEscapeOutput")
-  private boolean xmlEscapeOutput;
-
+public class ClojureRunTestMojo extends ClojureRunTestWithJUnitMojo {
   /**
    * Whether to produce junit output or not
    *
@@ -76,72 +29,9 @@ public class ClojureRunTestMojo extends AbstractClojureCompilerMojo {
   @Parameter(defaultValue = "false", property = "clojure.junitOutput")
   private boolean junitOutput;
 
-  public void execute() throws MojoExecutionException {
-    if (skip || skipTests) {
-      getLog().info("Test execution is skipped");
-    } else {
-      try {
-        final File[] testSourceDirectories = getSourceDirectories(SourceDirectory.TEST);
-        final File[] allSourceDirectories = getSourceDirectories(SourceDirectory.TEST, SourceDirectory.COMPILE);
-        final File outputFile = new File(testOutputDirectory);
-        final NamespaceInFile[] ns = new NamespaceDiscovery(getLog(), outputFile, charset, testDeclaredNamespaceOnly).discoverNamespacesIn(testNamespaces, testSourceDirectories);
-        File confFile = File.createTempFile("run-test", ".txt");
-        confFile.deleteOnExit();
-        final PrintWriter confWriter = new PrintWriter(new FileWriter(confFile));
-        generateConfig(confWriter, ns);
-        confWriter.close();
-        String testConf = confFile.getPath();
-
-        if (!isClasspathResource(testScript)) {
-          if (!isExistingTestScriptFile(testScript)) {
-            // Generate test script
-            outputFile.mkdir();
-
-            File testFile = File.createTempFile("run-test", ".clj");
-            testFile.deleteOnExit();
-            final PrintWriter writer = new PrintWriter(new FileWriter(testFile));
-
-            generateTestScript(writer, ns);
-
-            writer.close();
-
-            testScript = testFile.getPath();
-
-          // throw new MojoExecutionException("testScript is empty or does not exist!");
-          } else {
-            File testFile = new File(testScript);
-
-            if (!testFile.exists()) {
-              testFile = new File(getWorkingDirectory(), testScript);
-            }
-
-            if (!(testFile.exists())) {
-              throw new MojoExecutionException("testScript " + testFile.getPath() + " does not exist.");
-            }
-          }
-        }
-
-        getLog().debug("Running clojure:test against " + testScript);
-        callClojureWith(allSourceDirectories, outputDirectory, testClasspathElements, "clojure.main", new String[] {testScript, testConf});
-      } catch (IOException e) {
-        throw new MojoExecutionException(e.getMessage(), e);
-      }
-    }
-  }
-
-  protected void generateConfig(PrintWriter writer, NamespaceInFile[] ns) throws IOException {
-    Properties props = new Properties();
-    for(int i = 0; i < ns.length; i++) {
-      props.put("ns."+i, ns[i].getName());
-    }
+  protected Properties getProps(NamespaceInFile[] ns) {
+    Properties props = super.getProps(ns);
     props.put("junit", String.valueOf(junitOutput));
-    props.put("outputDir", testOutputDirectory);
-    props.put("xmlEscape", String.valueOf(xmlEscapeOutput));
-    props.store(writer,"Test Run Properties");
+    return props;
   }
-
-  protected void generateTestScript(PrintWriter writer, NamespaceInFile[] ns) throws IOException {
-    copy(ClojureRunTestMojo.class.getResourceAsStream("/default_test_script.clj"), writer);
-  }
-
 }

--- a/src/main/java/com/theoryinpractise/clojure/ClojureRunTestWithJUnitMojo.java
+++ b/src/main/java/com/theoryinpractise/clojure/ClojureRunTestWithJUnitMojo.java
@@ -127,47 +127,13 @@ public class ClojureRunTestWithJUnitMojo extends AbstractClojureCompilerMojo {
     for(int i = 0; i < ns.length; i++) {
       props.put("ns."+i, ns[i].getName());
     }
+    props.put("junit", "true");
+    props.put("outputDir", testOutputDirectory);
+    props.put("xmlEscape", String.valueOf(xmlEscapeOutput));
     props.store(writer,"Test Run Properties");
   }
 
   private void generateTestScript(PrintWriter writer, NamespaceInFile[] ns) throws IOException {
-    StringWriter testCljWriter = new StringWriter();
-    copy(ClojureRunTestWithJUnitMojo.class.getResourceAsStream("/default_test_script.clj"), testCljWriter);
-
-    StringBuilder runTestLine = new StringBuilder();
-    for (NamespaceInFile namespace : ns) {
-      if (xmlEscapeOutput) {
-        // Assumes with-junit-output uses with-test-out internally when necessary.  xml escape anything sent to *out*.
-        runTestLine.append("\n");
-        runTestLine.append("(with-open [writer (clojure.java.io/writer \"" + escapeFilePath(testOutputDirectory, namespace.getName() + ".xml") + "\") ");
-        runTestLine.append("            escaped (xml-escaping-writer writer)] ");
-        runTestLine.append("\n");
-        runTestLine.append("(binding [*test-out* writer *out* escaped]");
-        runTestLine.append("\n");
-        runTestLine.append(" (with-junit-output ");
-        runTestLine.append("\n");
-        runTestLine.append("(run-tests");
-        runTestLine.append(" '" + namespace.getName());
-        runTestLine.append("))))");
-      } else {
-        // Use with-test-out to fix with-junit-output for Clojure 1.2 (See http://dev.clojure.org/jira/browse/CLJ-431)
-        runTestLine.append("\n");
-        runTestLine.append("(with-open [writer (clojure.java.io/writer \"" + escapeFilePath(testOutputDirectory, namespace.getName() + ".xml") + "\")] ");
-        runTestLine.append("(binding [*test-out* writer] ");
-        runTestLine.append("\n");
-        runTestLine.append(" (with-test-out ");
-        runTestLine.append("\n");
-        runTestLine.append(" (with-junit-output ");
-        runTestLine.append("\n");
-        runTestLine.append("(run-tests");
-        runTestLine.append(" '" + namespace.getName());
-        runTestLine.append(")))))");
-      }
-    }
-
-    String testClj = testCljWriter.toString().replace("(run-tests)", runTestLine.toString());
-
-    writer.println(testClj);
+    copy(ClojureRunTestWithJUnitMojo.class.getResourceAsStream("/default_test_script.clj"), writer);
   }
-
 }

--- a/src/main/java/com/theoryinpractise/clojure/ClojureRunTestWithJUnitMojo.java
+++ b/src/main/java/com/theoryinpractise/clojure/ClojureRunTestWithJUnitMojo.java
@@ -89,10 +89,8 @@ public class ClojureRunTestWithJUnitMojo extends AbstractClojureCompilerMojo {
           ArrayList<NamespaceInFile> filteredNS = new ArrayList<NamespaceInFile>();
           String[] patterns = test.split("\\s*,\\s*");
           for (NamespaceInFile nsinf: ns) {
-            getLog().info("Checking test "+nsinf.getName());
             for ( String pattern: patterns) {
               if (nsinf.getName().contains(pattern)) {
-                getLog().info("Using test "+nsinf.getName());
                 filteredNS.add(nsinf);
                 break;
               }

--- a/src/main/java/com/theoryinpractise/clojure/ClojureRunTestWithJUnitMojo.java
+++ b/src/main/java/com/theoryinpractise/clojure/ClojureRunTestWithJUnitMojo.java
@@ -22,7 +22,6 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.util.Properties;
 
 import static org.apache.commons.io.IOUtils.copy;
@@ -124,14 +123,19 @@ public class ClojureRunTestWithJUnitMojo extends AbstractClojureCompilerMojo {
   }
 
   protected void generateConfig(PrintWriter writer, NamespaceInFile[] ns) throws IOException {
+    Properties props = getProps(ns);
+    props.store(writer,"Test Run Properties");
+  }
+
+  protected Properties getProps(NamespaceInFile[] ns) {
     Properties props = new Properties();
     for(int i = 0; i < ns.length; i++) {
       props.put("ns."+i, ns[i].getName());
     }
-    props.put("junit", "true");
+    props.put("junit", "True");
     props.put("outputDir", testOutputDirectory);
     props.put("xmlEscape", String.valueOf(xmlEscapeOutput));
-    props.store(writer,"Test Run Properties");
+    return props;
   }
 
   private void generateTestScript(PrintWriter writer, NamespaceInFile[] ns) throws IOException {

--- a/src/main/java/com/theoryinpractise/clojure/ClojureRunTestWithJUnitMojo.java
+++ b/src/main/java/com/theoryinpractise/clojure/ClojureRunTestWithJUnitMojo.java
@@ -80,6 +80,7 @@ public class ClojureRunTestWithJUnitMojo extends AbstractClojureCompilerMojo {
         final File outputFile = new File(testOutputDirectory);
         final NamespaceInFile[] ns = new NamespaceDiscovery(getLog(), outputFile, charset, testDeclaredNamespaceOnly).discoverNamespacesIn(testNamespaces, testSourceDirectories);
         File confFile = File.createTempFile("run-test", ".txt");
+        confFile.deleteOnExit();
         final PrintWriter confWriter = new PrintWriter(new FileWriter(confFile));
         generateConfig(confWriter, ns);
         confWriter.close();

--- a/src/main/resources/default_test_script.clj
+++ b/src/main/resources/default_test_script.clj
@@ -2,6 +2,7 @@
 
 (import `java.util.Properties)
 (import `java.io.FileInputStream)
+(import `java.io.FileWriter)
 (use 'clojure.test)
 (use 'clojure.test.junit)
 
@@ -11,9 +12,14 @@
 (def namespaces  (into [] 
                        (for [[key val] props
                              :when (.startsWith key "ns.")]
-                               val)))
+                               (symbol val))))
+
+(def junit (Boolean/valueOf (.get props "junit")))
+(def output-dir (.get props "outputDir"))
+(def xml-escape (Boolean/valueOf (.get props "xmlEscape")))
+
 (dorun (for [ns namespaces]
-  (require (symbol ns))))
+  (require ns)))
 
 (def escape-xml-map
   (zipmap "'<>\"&" (map #(str \& % \;) '[apos lt gt quot amp])))
@@ -42,8 +48,6 @@
   (if (> (total_errors results) 0)
     (println "There are test failures.")))
 
-(.println System/err (str "ARGS: " (pr-str *command-line-args*)))
-
 (when-not *compile-files*
   (let [results (atom {})]
     (let [report-orig report
@@ -54,7 +58,23 @@
                 junit-report (fn [x] (junit-report-orig x)
                                (swap! results (partial merge-with +)
                                  (select-keys (into {} (rest x)) [:pass :test :error :fail ])))]
-        (run-tests)))
+        (dorun (for [ns namespaces]
+          (if junit
+            (if xml-escape
+              (do
+                (with-open [writer (FileWriter. (str output-dir "/" ns ".xml"))
+                            escaped (xml-escaping-writer writer)]
+                            (binding [*test-out* writer *out* escaped]
+                              (with-junit-output
+                                (run-tests ns)))))
+              (do
+                ;;Use with-test-out to fix with-junit-output for Clojure 1.2 (See http://dev.clojure.org/jira/browse/CLJ-431)
+                (with-open [writer (FileWriter. (str output-dir "/" ns ".xml"))]
+                  (binding [*test-out* writer]
+                    (with-test-out
+                      (with-junit-output
+                        (run-tests ns)))))))
+            (run-tests ns))))
     (shutdown-agents)
     (print-results @results)
-    (System/exit (total_errors @results))))
+    (System/exit (total_errors @results))))))

--- a/src/main/resources/default_test_script.clj
+++ b/src/main/resources/default_test_script.clj
@@ -3,6 +3,9 @@
 (use 'clojure.test)
 (use 'clojure.test.junit)
 
+(dorun (for [ns *command-line-args*]
+  (require (symbol ns))))
+
 (def escape-xml-map
   (zipmap "'<>\"&" (map #(str \& % \;) '[apos lt gt quot amp])))
 
@@ -29,6 +32,8 @@
              ", Errors: " (:error results)))
   (if (> (total_errors results) 0)
     (println "There are test failures.")))
+
+(.println System/err (str "ARGS: " (pr-str *command-line-args*)))
 
 (when-not *compile-files*
   (let [results (atom {})]

--- a/src/main/resources/default_test_script.clj
+++ b/src/main/resources/default_test_script.clj
@@ -1,9 +1,18 @@
 (ns com.theoryinpractise.clojure.testrunner)
 
+(import `java.util.Properties)
+(import `java.io.FileInputStream)
 (use 'clojure.test)
 (use 'clojure.test.junit)
 
-(dorun (for [ns *command-line-args*]
+(def props (Properties.))
+(.load props (FileInputStream. (first *command-line-args*)))
+
+(def namespaces  (into [] 
+                       (for [[key val] props
+                             :when (.startsWith key "ns.")]
+                               val)))
+(dorun (for [ns namespaces]
   (require (symbol ns))))
 
 (def escape-xml-map


### PR DESCRIPTION
The original test runners did a lot of code generation, and were difficult to understand and extend because of that.  Things like trying to support -Dtest with a custom test runner script was essentially impossible.  This changes the test runner clojure code to be static, and instead of doing code generation it passes a config to the test runner script.  With the code being static and using a config we can now combine the code in the two Mojos so that there is only a single new config in ClojureRunTestMojo to control if we are outputting junit formatted results or not.  I also added in basic support for -Dtest to run a subset of unit tests.