### PR TITLE
Add support for .cljc files

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -22,7 +22,7 @@ To use this plugin and start compiling clojure code as part of your maven build,
     </plugins>
 
 Without any additional configuration, the clojure-maven-plugin will compile any
-namespaces in ./src/main/clojure/*.clj and ./src/test/clojure/*.clj.
+namespaces in ./src/main/clojure/*.clj (or .cljc) and ./src/test/clojure/*.clj (or .cljc).
 
 To change, or add additional source directories you can add the following configuration:
 
@@ -127,7 +127,7 @@ If you want to do no compilation at all, but copy all source files:
       <compileDeclaredNamespaceOnly>true</compileDeclaredNamespaceOnly>
     <configuration>
 
-Note that it will only copy clojure source files, which must a) end in .clj and b) contain a namespace declaration.
+Note that it will only copy clojure source files, which must a) end in .clj or .cljc and b) contain a namespace declaration.
 
 Enjoy.
 

--- a/src/main/java/com/theoryinpractise/clojure/NamespaceDiscovery.java
+++ b/src/main/java/com/theoryinpractise/clojure/NamespaceDiscovery.java
@@ -102,7 +102,8 @@ public class NamespaceDiscovery {
                     log.debug("Searching " + file.getPath() + " for clojure namespaces");
                     if (file.isDirectory()) {
                         namespaces.addAll(discoverNamespacesIn(basePath, file));
-                    } else if (file.getName().endsWith(".clj")) {
+                    } else if (file.getName().endsWith(".clj") || 
+                               file.getName().endsWith(".cljc")) {
                         namespaces.addAll(findNamespaceInFile(basePath, file));
                     }
                 }
@@ -133,7 +134,7 @@ public class NamespaceDiscovery {
                     String ns = file.getPath();
                     ns = ns.substring(
                             path.getPath().length() + 1,
-                            ns.length() - ".clj".length());
+                            ns.lastIndexOf("."));
                     ns = ns.replace(File.separatorChar, '.');
                     ns = ns.replace('_', '-');
 

--- a/src/main/java/com/theoryinpractise/clojure/NamespaceInFile.java
+++ b/src/main/java/com/theoryinpractise/clojure/NamespaceInFile.java
@@ -29,7 +29,10 @@ public class NamespaceInFile {
     }
 
     public String getFilename() {
-        return namespace.replace('.', File.separatorChar).replace('-', '_') + ".clj";
+        String base = namespace.replace('.', File.separatorChar).replace('-', '_');
+        String sourceName = sourceFile.getName();
+        String suffix = sourceName.substring(sourceName.lastIndexOf("."));
+        return base + suffix;
     }
 
     public File getSourceFile() {


### PR DESCRIPTION
The new Clojure 1.7 reader conditional support includes a new file extension .cljc - this commit adds support for handling those. All changes should be backwards-compatible with older Clojure versions (just finds a wider set of files that did not previously exist).