### PR TITLE
Fix version in getting started section

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -28,7 +28,7 @@ To use this plugin and start working with clojure, start with a blank maven proj
     <plugin>
       <groupId>com.theoryinpractise</groupId>
       <artifactId>clojure-maven-plugin</artifactId>
-      <version>1.8.1</version>
+      <version>1.7.1</version>
       <extensions>true</extensions>
     </plugin>
   </plugins>


### PR DESCRIPTION
I could be confused, but I believe the latest published artifact at Maven Central is 1.7.1, not 1.8.1

https://search.maven.org/#artifactdetails%7Ccom.theoryinpractise%7Cclojure-maven-plugin%7C1.7.1%7Cmaven-plugin