### PR TITLE
Do not swallow failure information

### DIFF
--- a/src/main/java/com/theoryinpractise/clojure/AbstractClojureCompilerMojo.java
+++ b/src/main/java/com/theoryinpractise/clojure/AbstractClojureCompilerMojo.java
@@ -443,16 +443,19 @@ public abstract class AbstractClojureCompilerMojo extends AbstractMojo {
     exec.setProcessDestroyer(destroyer);
 
     int status;
+    Exception failureException = null;
     try {
       status = exec.execute(cl, env);
     } catch (ExecuteException e) {
       status = e.getExitValue();
+      failureException = e;
     } catch (IOException e) {
       status = 1;
+      failureException = e;
     }
 
     if (status != 0) {
-      throw new MojoExecutionException("Clojure failed.");
+      throw new MojoExecutionException("Clojure failed.", failureException);
     }
   }
 

--- a/src/main/java/com/theoryinpractise/clojure/AbstractClojureCompilerMojo.java
+++ b/src/main/java/com/theoryinpractise/clojure/AbstractClojureCompilerMojo.java
@@ -455,7 +455,7 @@ public abstract class AbstractClojureCompilerMojo extends AbstractMojo {
     }
 
     if (status != 0) {
-      throw new MojoExecutionException("Clojure failed.", failureException);
+      throw new MojoExecutionException("Clojure failed with exit value " + status + ".", failureException);
     }
   }
 


### PR DESCRIPTION
Our clojure build failed with this failure when building on a new platform:

Caused by: org.apache.maven.plugin.MojoExecutionException: Clojure failed.

This is not very useful when debugging the real issue.  This PR adds the failure information.

