### PR TITLE
Update to commons-lang3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,9 +137,9 @@
             <version>2.6</version>
         </dependency>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>2.6</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.8.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>

--- a/src/main/java/com/theoryinpractise/clojure/AbstractClojureCompilerMojo.java
+++ b/src/main/java/com/theoryinpractise/clojure/AbstractClojureCompilerMojo.java
@@ -20,7 +20,7 @@ import org.apache.commons.exec.ExecuteStreamHandler;
 import org.apache.commons.exec.Executor;
 import org.apache.commons.exec.PumpStreamHandler;
 import org.apache.commons.exec.ShutdownHookProcessDestroyer;
-import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;

--- a/src/main/java/com/theoryinpractise/clojure/ClojureNReplMojo.java
+++ b/src/main/java/com/theoryinpractise/clojure/ClojureNReplMojo.java
@@ -16,7 +16,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;

--- a/src/main/java/com/theoryinpractise/clojure/ClojureSwankMojo.java
+++ b/src/main/java/com/theoryinpractise/clojure/ClojureSwankMojo.java
@@ -12,7 +12,7 @@
 
 package com.theoryinpractise.clojure;
 
-import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;


### PR DESCRIPTION
The commons-lang3 is currently maintained version, whicle the commons-lang 2.6 is a legacy release. Requires Java7, supports newer releases as well.