### PR TITLE
*ns* is never bound to the test namespace

### DIFF
--- a/src/it/test-with-junit/src/test/clojure/ns_binding_test.clj
+++ b/src/it/test-with-junit/src/test/clojure/ns_binding_test.clj
@@ -1,0 +1,5 @@
+(ns ns-binding-test
+  (:require [clojure.test :refer :all]))
+
+(deftest atest
+  (is (= 'ns-binding-test (ns-name *ns*))))

--- a/src/it/test-with-junit/verify.bsh
+++ b/src/it/test-with-junit/verify.bsh
@@ -1,35 +1,42 @@
 import java.io.*;
 
-File file = new File( basedir, "target/test-reports/succeeding.xml" );
-if ( !file.isFile() ) {
-    throw new FileNotFoundException( "Could not find generated report: " + file );
+void verifyXmlFile(File baseDir, String namespace) throws Exception {
+    File file = new File(baseDir, "target/test-reports/" + namespace + ".xml");
+    if (!file.isFile()) {
+        throw new FileNotFoundException("Could not find generated report: " + file);
+    }
+    Reader r = new BufferedReader(new FileReader(file));
+    String line = r.readLine().trim();
+    String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>";
+    if (!expected.equals(line)) {
+        throw new RuntimeException("line 1 should be " + expected + " but was:" + line);
+    }
+    line = r.readLine().trim();
+    if (!"<testsuites>".equals(line)) {
+        throw new RuntimeException("line 2 should be <testsuites> but was:" + line);
+    }
+    line = r.readLine().trim();
+    if (!("<testsuite name=\"" + namespace + "\">").equals(line)) {
+        throw new RuntimeException("line 3 should be <testsuite name=\"" + namespace + "\"> but was:" + line);
+    }
+    line = r.readLine().trim();
+    if (!("<testcase name=\"atest\" classname=\"" + namespace + "\">").equals(line)) {
+        throw new RuntimeException("line 4 should be <testcase name=\"atest\" classname=\"" + namespace + "\"> but was:" + line);
+    }
+    line = r.readLine().trim();
+    if (!"</testcase>".equals(line)) {
+        throw new RuntimeException("line 5 should be [</testcase>] but was:" + line);
+    }
+    line = r.readLine().trim();
+    if (!"</testsuite>".equals(line)) {
+        throw new RuntimeException("line 6 should be [</testsuite>] but was:" + line);
+    }
+    line = r.readLine().trim();
+    if (!"</testsuites>".equals(line)) {
+        throw new RuntimeException("line 7 should be [</testsuites>] but was:" + line);
+    }
+    r.close();
 }
-Reader r = new BufferedReader(new FileReader(file));
-String line = r.readLine().trim();
-if (!"<?xml version=\"1.0\" encoding=\"UTF-8\"?>".equals(line)) {
-	throw new RuntimeException("line 1 should be <?xml version=\"1.0\" encoding=\"UTF-8\"?> but was:" + line);
-}
-line = r.readLine().trim();
-if (!"<testsuites>".equals(line)) {
-	throw new RuntimeException("line 2 should be <testsuites> but was:" + line);
-}
-line = r.readLine().trim();
-if (!"<testsuite name=\"succeeding\">".equals(line)) {
-	throw new RuntimeException("line 3 should be <testsuite name=\"succeeding\"> but was:" + line);
-}
-line = r.readLine().trim();
-if (!"<testcase name=\"atest\" classname=\"succeeding\">".equals(line)) {
-	throw new RuntimeException("line 4 should be [<testcase name=\"atest\" classname=\"succeeding\">] but was:" + line);
-}
-line = r.readLine().trim();
-if (!"</testcase>".equals(line)) {
-	throw new RuntimeException("line 5 should be [</testcase>] but was:" + line);
-}
-line = r.readLine().trim();
-if (!"</testsuite>".equals(line)) {
-	throw new RuntimeException("line 6 should be [</testsuite>] but was:" + line);
-}
-line = r.readLine().trim();
-if (!"</testsuites>".equals(line)) {
-	throw new RuntimeException("line 7 should be [</testsuites>] but was:" + line);
-}
+
+verifyXmlFile(basedir, "succeeding");
+verifyXmlFile(basedir, "ns-binding-test");

--- a/src/main/resources/default_test_script.clj
+++ b/src/main/resources/default_test_script.clj
@@ -1,8 +1,8 @@
 (ns com.theoryinpractise.clojure.testrunner)
 
-(import `java.util.Properties)
-(import `java.io.FileInputStream)
-(import `java.io.FileWriter)
+(import java.util.Properties)
+(import java.io.FileInputStream)
+(import java.io.FileWriter)
 (use 'clojure.test)
 (use 'clojure.test.junit)
 
@@ -48,38 +48,39 @@
     (println "There are test failures.")))
 
 (when-not *compile-files*
-  (let [results (atom {})]
-    (let [report-orig report
-          junit-report-orig junit-report
-          out-orig *out*
-          test-out-orig *test-out*]
-      (binding [report (fn [x] (report-orig x)
-                         (swap! results (partial merge-with +)
-                                (select-keys (into {} (rest x)) [:pass :test :error :fail])))
-                junit-report (fn [x]
-                               (junit-report-orig x)
-                               (binding [*test-out* test-out-orig
-                                         *out*      out-orig]
-                                 (report-orig x))
-                               (swap! results (partial merge-with +)
-                                      (select-keys (into {} (rest x)) [:pass :test :error :fail])))]
-        (dorun (for [ns namespaces]
-                 (if junit
-                   (if xml-escape
-                     (do
-                       (with-open [writer (FileWriter. (str output-dir "/" ns ".xml"))
-                                   escaped (xml-escaping-writer writer)]
-                         (binding [*test-out* writer *out* escaped]
-                           (with-junit-output
-                             (run-tests ns)))))
-                     (do
-                ;;Use with-test-out to fix with-junit-output for Clojure 1.2 (See http://dev.clojure.org/jira/browse/CLJ-431)
-                       (with-open [writer (FileWriter. (str output-dir "/" ns ".xml"))]
-                         (binding [*test-out* writer]
-                           (with-test-out
-                             (with-junit-output
-                               (run-tests ns)))))))
-                   (run-tests ns))))
-        (shutdown-agents)
-        (print-results @results)
-        (System/exit (total_errors @results))))))
+  (let [results (atom {})
+        report-orig report
+        junit-report-orig junit-report
+        out-orig *out*
+        test-out-orig *test-out*]
+    (binding [report (fn [x] (report-orig x)
+                       (swap! results (partial merge-with +)
+                              (select-keys (into {} (rest x)) [:pass :test :error :fail])))
+              junit-report (fn [x]
+                             (junit-report-orig x)
+                             (binding [*test-out* test-out-orig
+                                       *out*      out-orig]
+                               (report-orig x))
+                             (swap! results (partial merge-with +)
+                                    (select-keys (into {} (rest x)) [:pass :test :error :fail])))]
+      (dorun (for [ns namespaces]
+               (if junit
+                 (if xml-escape
+                   (with-open [writer (FileWriter. (str output-dir "/" ns ".xml"))
+                               escaped (xml-escaping-writer writer)]
+                     (binding [*test-out* writer *out* escaped]
+                       (with-junit-output
+                         (binding [*ns* (the-ns ns)]
+                           (run-tests ns)))))
+                   ;;Use with-test-out to fix with-junit-output for Clojure 1.2 (See http://dev.clojure.org/jira/browse/CLJ-431)
+                   (with-open [writer (FileWriter. (str output-dir "/" ns ".xml"))]
+                     (binding [*test-out* writer]
+                       (with-test-out
+                         (with-junit-output
+                           (binding [*ns* (the-ns ns)]
+                             (run-tests ns)))))))
+                 (binding [*ns* (the-ns ns)]
+                   (run-tests ns)))))
+      (shutdown-agents)
+      (print-results @results)
+      (System/exit (total_errors @results)))))


### PR DESCRIPTION
The test runner script is src/main/resources/default_test_script.clj. It runs in the com.theoryinpractise.clojure.testrunner namespace and calls (require ns) followed by (run-tests ns) for each discovered test namespace.

The bug: *ns* is never bound to the test namespace before run-tests is called. While deftest functions carry their own namespace at definition time (so symbol resolution within test bodies generally works), *ns* remains set to com.theoryinpractise.clojure.testrunner throughout. This breaks:

1. Tests that read *ns* directly (e.g., (is (= 'my.ns (ns-name *ns*))))
2. Tests using resolve, intern, find-var with unqualified symbols
3. Tests that eval, load-string, or read-string code
4. test-ns-hook functions that depend on *ns* being correct

Single file to change: src/main/resources/default_test_script.clj Wrap all three (run-tests ns) calls with (binding [*ns* (the-ns ns)] ...)

This is a small, targeted fix that's consistent with how other Clojure test tools handle namespace context.

The fix ensures that *ns* is bound to the correct test namespace when run-tests executes, so tests that use resolve, intern, *ns* directly, or other namespace-sensitive operations get the correct namespace context instead of com.theoryinpractise.clojure.testrunner.